### PR TITLE
Fix macOS deployment prerequisites and SQL seed dates

### DIFF
--- a/deployment/Deploy.ps1
+++ b/deployment/Deploy.ps1
@@ -197,10 +197,29 @@ if(!($KeyVault -match "^[a-zA-Z][a-z0-9-]+$")) {
 
 # check if dotnet 8 is installed
 
-$dotnetversion = dotnet --version
+$dotnetRoot = Join-Path $HOME '.dotnet'
+$dotnetTools = Join-Path $dotnetRoot 'tools'
+$env:PATH = "$dotnetRoot$([IO.Path]::PathSeparator)$dotnetTools$([IO.Path]::PathSeparator)$env:PATH"
+
+$dotnetversion = dotnet --version 2>$null
+
+if($LASTEXITCODE -ne 0) {
+    Throw "🛑 Dotnet 8 SDK not installed. Install dotnet 8.0.303 and re-run the script."
+    Exit
+}
 
 if(!$dotnetversion.StartsWith('8.')) {
-    Throw "🛑 Dotnet 8 not installed. Install dotnet8 and re-run the script."
+    Throw "🛑 Dotnet 8 SDK not installed. Install dotnet 8.0.303 and re-run the script."
+    Exit
+}
+
+if (!(Get-Command dotnet-ef -ErrorAction SilentlyContinue)) {
+    Throw "🛑 dotnet-ef not found. Run: dotnet tool install --global dotnet-ef --version 8.0.6"
+    Exit
+}
+
+if (!(Get-Command Invoke-Sqlcmd -ErrorAction SilentlyContinue)) {
+    Throw "🛑 Invoke-Sqlcmd not found. Run: Install-Module -Name SqlServer -AllowClobber"
     Exit
 }
 
@@ -211,7 +230,7 @@ Write-Host "Starting SaaS Accelerator Deployment..."
 
 
 #region Check If SQL Server Exist
-$sql_exists = Get-AzureRmSqlServer -ServerName $SQLServerName -ResourceGroupName $ResourceGroupForDeployment -ErrorAction SilentlyContinue
+$sql_exists = Get-AzSqlServer -ServerName $SQLServerName -ResourceGroupName $ResourceGroupForDeployment -ErrorAction SilentlyContinue
 if ($sql_exists) 
 {
 	Write-Host ""
@@ -457,19 +476,31 @@ if (!($ADMTApplicationIDPortal)) {
 
 #region Prepare Code Packages
 Write-host "📜 Prepare publish files for the application"
-if (!(Test-Path '../Publish')) {		
+
+$adminSitePackage = '../Publish/AdminSite.zip'
+$customerSitePackage = '../Publish/CustomerSite.zip'
+
+if (!(Test-Path $adminSitePackage) -or !(Test-Path $customerSitePackage)) {
+	New-Item -ItemType Directory -Path '../Publish' -Force | Out-Null
+
 	Write-host "   🔵 Preparing Admin Site"  
 	dotnet publish ../src/AdminSite/AdminSite.csproj -c release -o ../Publish/AdminSite/ -v q
+	if ($LASTEXITCODE -ne 0) { Throw "🛑 Admin Site publish failed." }
 
 	Write-host "   🔵 Preparing Metered Scheduler"
 	dotnet publish ../src/MeteredTriggerJob/MeteredTriggerJob.csproj -c release -o ../Publish/AdminSite/app_data/jobs/triggered/MeteredTriggerJob/ -v q --runtime win-x64 --self-contained true 
+	if ($LASTEXITCODE -ne 0) { Throw "🛑 Metered Scheduler publish failed." }
 
 	Write-host "   🔵 Preparing Customer Site"
 	dotnet publish ../src/CustomerSite/CustomerSite.csproj -c release -o ../Publish/CustomerSite/ -v q
+	if ($LASTEXITCODE -ne 0) { Throw "🛑 Customer Site publish failed." }
+
+	if (!(Test-Path '../Publish/AdminSite')) { Throw "🛑 Admin Site publish output was not created." }
+	if (!(Test-Path '../Publish/CustomerSite')) { Throw "🛑 Customer Site publish output was not created." }
 
 	Write-host "   🔵 Zipping packages"
-	Compress-Archive -Path ../Publish/AdminSite/* -DestinationPath ../Publish/AdminSite.zip -Force
-	Compress-Archive -Path ../Publish/CustomerSite/* -DestinationPath ../Publish/CustomerSite.zip -Force
+	Compress-Archive -Path ../Publish/AdminSite/* -DestinationPath $adminSitePackage -Force
+	Compress-Archive -Path ../Publish/CustomerSite/* -DestinationPath $customerSitePackage -Force
 }
 #endregion
 

--- a/docs/Advanced-Instructions.md
+++ b/docs/Advanced-Instructions.md
@@ -51,25 +51,38 @@ cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `
 
 ### Local deployment
 
-   1. Install Powershell 7.0.2
+   1. Install PowerShell 7.
    - [Windows Store](https://www.microsoft.com/store/productId/9MZ1SNWT0N5D)
    - [GitHub](https://github.com/PowerShell/PowerShell/releases)
-   2. Start a Windows PowerShell window as administrator and run the following commands to install Azure modules:
-> Note: Make sure that you are using the latest Powershell version to avoid issues in Compress-Archive in 5.1 that got resolved in the latest version.
+   - [macOS install instructions](https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-macos)
+   2. Install the Azure CLI and sign in with the subscription that will host the deployment.
+```powershell
+az login --tenant <tenant-id>
+```
+   3. Install the .NET SDK version pinned by `global.json` and the Entity Framework CLI tool.
+```powershell
+Invoke-WebRequest https://dot.net/v1/dotnet-install.sh -OutFile dotnet-install.sh
+chmod +x ./dotnet-install.sh
+./dotnet-install.sh -version 8.0.303
+$ENV:PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$ENV:PATH"
+dotnet tool install --global dotnet-ef --version 8.0.6
+```
+   4. Start PowerShell 7 (`pwsh`) and run the following command to install Azure modules:
+> Note: Make sure that you are using the latest PowerShell version to avoid issues in Compress-Archive in 5.1 that got resolved in the latest version.
 ```powershell
 Install-Module -Name Az -AllowClobber
+Install-Module -Name SqlServer -AllowClobber
 ```
-   3. Clone the repository
-   4. Navigate to the folder **.\deployment**
-   5. Set the priorities running
+   5. Clone the repository
+   6. Navigate to the folder **./deployment**
+   7. On Windows, set the execution policy for the current PowerShell process.
 ```powershell
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 ```
-   6. Choose "A", to change the policy to Yes to All. If you get a permission error, you can try:
+   8. Choose "A", to change the policy to Yes to All. If you get a permission error, you can try:
         * Run the PowerShell terminal as an Administrator
         * Set the priorities running Set-ExecutionPolicy -ExecutionPolicy unrestricted.
-   7. Run the command **Connect-AzureAD -Confirm** for the App Registration
-   8. Run the command **.\Deploy.ps1** with the following paramters
+   9. Run the command **./Deploy.ps1** with the following parameters
 
 | Parameter | Description |
 |-----------| -------------|
@@ -91,7 +104,7 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 
 > **Example** 
 ```powershell
-.\Deploy.ps1 `
+./Deploy.ps1 `
     -WebAppNamePrefix "contoso" `
     -TenantID "tenandId" `
     -ADApplicationID "single-tenant clientId" `

--- a/docs/Deployment-Notes.md
+++ b/docs/Deployment-Notes.md
@@ -44,3 +44,12 @@ Install-Module -Name SqlServer -AllowClobber
 - Fulfillment API App Registration: `fab1c0bb-f913-4d5a-a304-e55561f06c6b`
 - Admin Portal SSO App Registration: `4698951b-b2af-4e93-8b72-29b41b63710d`
 - Landing Page SSO App Registration: `6ba6401e-4244-4b5a-ab14-80567b94ef4a`
+
+## Post-Install Checklist
+
+If the installation completed without error, complete the following checklist in Partner Center SaaS Technical Configuration:
+
+- Landing Page section: `https://PdMarketAccel-portal.azurewebsites.net/`
+- Connection Webhook section: `https://PdMarketAccel-portal.azurewebsites.net/api/AzureWebhook`
+- Tenant ID: `d49110b2-6f26-4c66-b723-1729cdb9a3cf`
+- AAD Application ID section: `fab1c0bb-f913-4d5a-a304-e55561f06c6b`

--- a/docs/Deployment-Notes.md
+++ b/docs/Deployment-Notes.md
@@ -1,0 +1,46 @@
+# Deployment Notes
+
+## Mesh Deployment
+
+[Deployed to Mesh Tenant](https://portal.azure.com/#@meshsystems.com/resource/subscriptions/13e3ba18-4cd3-4abd-b6b9-945258a5236f/resourceGroups/rg-marketplace-accelerator-pd/overview)
+
+## Deployment Parameters
+
+```powershell
+./Deploy.ps1 `
+ -WebAppNamePrefix "PdMarketAccel" `
+ -ResourceGroupForDeployment "rg-marketplace-accelerator-pd" `
+ -PublisherAdminUsers "austin.delarosa@meshsystems.com,mike.coleman@meshsystems.com,kyle.burns@meshsystems.com" `
+ -Location "Central US" `
+ -AzureSubscriptionID "13e3ba18-4cd3-4abd-b6b9-945258a5236f" `
+ -TenantID "d49110b2-6f26-4c66-b723-1729cdb9a3cf"
+```
+
+## macOS Prerequisites
+
+Run from PowerShell 7 (`pwsh`). The repo has a `global.json` pin for .NET SDK `8.0.303`, so .NET 10 alone is not enough.
+
+```powershell
+az login --tenant d49110b2-6f26-4c66-b723-1729cdb9a3cf
+Invoke-WebRequest https://dot.net/v1/dotnet-install.sh -OutFile dotnet-install.sh
+chmod +x ./dotnet-install.sh
+./dotnet-install.sh -version 8.0.303
+$ENV:PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$ENV:PATH"
+dotnet tool install --global dotnet-ef --version 8.0.6
+Install-Module -Name Az -AllowClobber
+Install-Module -Name SqlServer -AllowClobber
+```
+
+## Known Issues Fixed Locally
+
+- `Get-AzureRmSqlServer` failed because AzureRM cmdlets are deprecated and not available on the Mac setup. `Deploy.ps1` now uses `Get-AzSqlServer`.
+- `Compress-Archive` failed with missing `../Publish` because `dotnet publish` failed before package creation. The script now checks the required .NET SDK, creates `../Publish`, and fails fast after each publish command.
+- `Invoke-Sqlcmd` failed because it is provided by the `SqlServer` PowerShell module. Install it with `Install-Module -Name SqlServer -AllowClobber`.
+- `dotnet-ef 8.0.0` emitted a version warning against EF Core runtime `8.0.6`. Use `dotnet-ef 8.0.6` for this repo.
+- SQL migration execution failed with `Conversion failed when converting date and/or time from character string` because generated seed SQL used local-culture `DateTime.Now` strings from macOS. `BaselineV2_Seed.cs` now emits ISO 8601 UTC datetime strings for SQL Server-safe seed values.
+
+## Created App Registrations
+
+- Fulfillment API App Registration: `fab1c0bb-f913-4d5a-a304-e55561f06c6b`
+- Admin Portal SSO App Registration: `4698951b-b2af-4e93-8b72-29b41b63710d`
+- Landing Page SSO App Registration: `6ba6401e-4244-4b5a-ab14-80567b94ef4a`

--- a/docs/Installation-Instructions.md
+++ b/docs/Installation-Instructions.md
@@ -38,14 +38,14 @@ wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh; `
 chmod +x dotnet-install.sh; `
 ./dotnet-install.sh -version 8.0.303; `
 $ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `
-dotnet tool install --global dotnet-ef --version 8.0.0; `
+dotnet tool install --global dotnet-ef --version 8.0.6; `
 git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b 8.2.1 --depth 1; `
 cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `
 .\Deploy.ps1 `
- -WebAppNamePrefix "SOME-UNIQUE-STRING" `
- -ResourceGroupForDeployment "SOME-RG-NAME" `
- -PublisherAdminUsers "user1@email.com,user2@email" `
- -Location "East US" 
+ -WebAppNamePrefix "PdMarketAccel" `
+ -ResourceGroupForDeployment "rg-marketplace-accelerator-pd" `
+ -PublisherAdminUsers "austin.delarosa@meshsystems.com,mike.coleman@meshsystems.com,kyle.burns@meshsystems.com" `
+ -Location "Central US" 
  ```
 
 The script above will perform the following actions.
@@ -85,7 +85,7 @@ wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh; `
 chmod +x dotnet-install.sh; `
 ./dotnet-install.sh -version 8.0.303; `
 $ENV:PATH="$HOME/.dotnet:$ENV:PATH"; `
-dotnet tool install --global dotnet-ef --version 8.0.0; `
+dotnet tool install --global dotnet-ef --version 8.0.6; `
 git clone https://github.com/Azure/Commercial-Marketplace-SaaS-Accelerator.git -b <release-version-branch-to-deploy> --depth 1; `
 cd ./Commercial-Marketplace-SaaS-Accelerator/deployment; `
 .\Upgrade.ps1 `
@@ -122,6 +122,27 @@ The video is rather lengthy, so use the chapter links in the video description t
 
 ## Alternative deployments
 There are other ways to deploy the SaaS Accelerator environment (e.g. development, maual deployment, etc).  Additional instruction can be found [here](Advanced-Instructions.md).
+
+For local deployment from macOS, run the script from PowerShell 7 with Azure CLI authenticated and the Az PowerShell module installed:
+
+```powershell
+az login --tenant <tenant-id>
+Invoke-WebRequest https://dot.net/v1/dotnet-install.sh -OutFile dotnet-install.sh
+chmod +x ./dotnet-install.sh
+./dotnet-install.sh -version 8.0.303
+$ENV:PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$ENV:PATH"
+dotnet tool install --global dotnet-ef --version 8.0.6
+Install-Module -Name Az -AllowClobber
+Install-Module -Name SqlServer -AllowClobber
+cd ./Commercial-Marketplace-SaaS-Accelerator/deployment
+./Deploy.ps1 `
+ -WebAppNamePrefix "SOME-UNIQUE-STRING" `
+ -ResourceGroupForDeployment "SOME-RG-NAME" `
+ -PublisherAdminUsers "user1@email.com,user2@email.com" `
+ -Location "East US" `
+ -TenantID "tenant-id" `
+ -AzureSubscriptionID "subscription-id"
+```
 
 ## Authentication between the WebApps and the Database
 The Webapps uses Managed Identity to communicate with the database. The Managed Identity is created during the deployment of the WebApps. The Managed Identity is then used to create a user in the database and grant the user the necessary permissions. The connection string used by the WebApps to connect to the database is then updated to use the Managed Identity.

--- a/src/DataAccess/Migrations/Custom/BaselineV2_Seed.cs
+++ b/src/DataAccess/Migrations/Custom/BaselineV2_Seed.cs
@@ -343,7 +343,7 @@ EXEC(N'
 
         public static void BaselineV2_SeedData(this MigrationBuilder migrationBuilder)
         {
-            var seedDate = DateTime.Now;
+            var seedDate = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fff");
             migrationBuilder.Sql(@$"
 INSERT INTO ValueTypes
     (ValueType,CreateDate,HTMLType)

--- a/tasks/CURRENT.md
+++ b/tasks/CURRENT.md
@@ -1,0 +1,45 @@
+# Current Tasks
+
+## Goal
+
+Deploy the Commercial Marketplace SaaS Accelerator from macOS.
+
+## Context
+
+The deployment script fails in PowerShell with:
+
+```text
+Deploy.ps1: The term 'Get-AzureRmSqlServer' is not recognized as a name of a cmdlet, function, script file, or executable program.
+```
+
+The command being run passes `WebAppNamePrefix`, deployment resource group, publisher admin users, Azure location, subscription ID, and tenant ID.
+
+## Tasks
+
+- [x] Inspect `Deploy.ps1` and supporting deployment scripts.
+- [x] Identify all AzureRM module dependencies and deprecated cmdlets.
+- [x] Convert the deployment flow to macOS-compatible Az PowerShell cmdlets where feasible.
+- [x] Validate script syntax and any available non-destructive checks.
+- [x] Document the macOS deployment command and required prerequisites if missing.
+
+## Progress
+
+- Replaced deprecated `Get-AzureRmSqlServer` with `Get-AzSqlServer`.
+- Updated local deployment documentation for macOS/PowerShell 7 usage.
+- Verified `Deploy.ps1` parses successfully in PowerShell 7.
+- Verified no remaining AzureRM references in PowerShell scripts.
+- Verified `Get-AzSqlServer` is available in the local PowerShell environment.
+- Fixed package preparation so `../Publish` is created before compression.
+- Added fail-fast checks after each `dotnet publish` command so publish errors are reported directly instead of surfacing as `Compress-Archive` path errors.
+- Found local .NET SDK mismatch: `global.json` requires `8.0.303`, but only `10.0.108` is installed.
+- Restored deploy script preflight validation for the required .NET 8 SDK.
+- Added macOS documentation for installing .NET SDK `8.0.303` and `dotnet-ef`.
+- Added `$HOME/.dotnet/tools` to `PATH` during deployment and preflight validation for `dotnet-ef`.
+- Added preflight validation for `Invoke-Sqlcmd` and documented the `SqlServer` PowerShell module dependency.
+- Updated documented `dotnet-ef` version from `8.0.0` to `8.0.6` to match EF Core package references.
+- Fixed `BaselineV2_Seed.cs` to emit ISO 8601 UTC seed dates instead of local-culture `DateTime.Now` strings that SQL Server could not parse.
+
+## Notes
+
+- Do not run destructive Azure deployment operations without explicit user approval.
+- Git write operations require explicit user approval.

--- a/tasks/CURRENT.md
+++ b/tasks/CURRENT.md
@@ -38,6 +38,7 @@ The command being run passes `WebAppNamePrefix`, deployment resource group, publ
 - Added preflight validation for `Invoke-Sqlcmd` and documented the `SqlServer` PowerShell module dependency.
 - Updated documented `dotnet-ef` version from `8.0.0` to `8.0.6` to match EF Core package references.
 - Fixed `BaselineV2_Seed.cs` to emit ISO 8601 UTC seed dates instead of local-culture `DateTime.Now` strings that SQL Server could not parse.
+- Added the Partner Center post-install checklist to `docs/Deployment-Notes.md`.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Add preflight checks for dotnet-ef and Invoke-Sqlcmd on macOS
- Update deployment docs for PowerShell 7, .NET SDK 8.0.303, SqlServer, and dotnet-ef 8.0.6
- Emit ISO 8601 UTC seed dates from BaselineV2_Seed.cs so generated SQL runs on SQL Server

## Notes
- The generated deployment/script.sql and downloaded deployment/dotnet-install.sh were not included in the commit.
- The branch includes a deployment notes doc for posterity.
